### PR TITLE
Pictures via channels

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,20 +1,81 @@
-# AThousandWords
+# A Thousand Words
 
-This app has two parts: a Phoenix app and a React app.
+A Thousand Words lets you geotag old photos and view them on a map through space as well as time.
 
-The React app lives in `priv/a_thousand_words`, it uses `create-react-app`.
+## Pre-Installation
 
-You can start its own development server by running `cd priv/a_thousand_words/ && npm start` and look at `localhost:3000`.
+This app has two parts: a Phoenix app for backend and a React app for frontend.  
+
+### To get the Phoenix app installed:  
+
+You'll need to install [Elixir 1.4](https://elixir-lang.org/install.html) and Erlang if you don't already have it.  
+  
+Next, you should install [Hex](https://hex.pm/) the package manager for Elixir by running `mix local.hex`  
+
+Now you can install [Phoenix 1.3](http://www.phoenixframework.org/) by running `mix archive.install https://github.com/phoenixframework/archives/raw/master/phoenix_new.ez`  
+
+You also need to install [Postgres](https://wiki.postgresql.org/wiki/Detailed_installation_guides) which is the DB being used by Phoenix.  
+
+### To get the React app installed:  
+
+You'll need to install [node v6.11.* and npm v3.10.*](https://nodejs.org/en/download/)  
+
+## Fetching dependencies  
+### Repo
+- Clone the repo
+- `cd` into it  
+
+### Phoenix App
+- Fetch Phoenix dependencies with `mix deps.get`  
+- Start postgres in your chosen manner  
+- Start the Ecto Repository with `mix ecto.create`
+- Run all migrations with `mix ecto.migrate`
+- Insert seed data to your dev db with `mix run priv/repo/seeds.exs`
+- Run tests with `mix test`  
+
+### React App  
+- Change to the React App root directory `cd priv/a_thousand_words`
+- Fetch the React Dependencies with `npm install`
+
+If that all worked, congratulations! You have a working Phoenix backend and React frontend.  
+
+## Spinning up the servers  
+
+The backend and frontend apps are separate beasts, and they communicate primarily using Websockets. 
+The phoenix app eventually serves the react app as a bundle in production, but for development **you need to start two separate dev servers.**   
+
+### Phoenix server
+
+ It is not expected that you use the phoenix dev server to interact with the UI, only to dev against the JSON api. Because of the configuration, Phoenix will live reload code in Elixir files _but will not live reload the javascript code in the react app._ I am providing a react frontend but theoretically you could use any other method to interact with this Phoenix API.
+
+ To start the Phoenix server, run `mix phx.server`.  
+ It will be on port `4000`.
+
+
+### React server
+
+The React app lives in `priv/a_thousand_words`, it uses [create-react-app](https://github.com/facebookincubator/create-react-app) which, among other things, provides a dev server.
+
+You can start this development server by running  
+`cd priv/a_thousand_words/ && npm start`.  
+By default it runs on port `3000`.
 
 The phoenix server looks in `priv/a_thousand_words/build` for the static assets, which are only updated
-when you run `cd priv/a_thousand_words/ && npm run build`. Use the React development server when developing UI.
+when you run a special script in the React app.
 
-To run the Phoenix server, run `mix phx.server`. It will be on `localhost:4000`. *Remember: the Phoenix app only looks in `priv/a_thousand_words/build` so will not update when you save changes to JS files.*
+### To create a build of the react app that Phoenix can deploy
+run `cd priv/a_thousand_words/ && npm run build`.  
+This creates a bundle that is written to `priv/a_thousand_words/build`.  
+Phoenix is configured to look in this directory and deploy the JS from there only, which makes it difficult to actually develop using the phoenix dev server (as you would be continually building the production bundle each time you made a change.)  
 
-For all intents and purposes, these are two completely separate apps. 
+Use the React development server when developing UI.  
 
-Some of the resources I used when setting this up:  
+ Only run `npm build` if you're deploying.
 
-_Making react and phoenix talk via websockets_  
+ **Remember: the Phoenix app only looks in `priv/a_thousand_words/build` so while it is possible to use the phoenix dev server on port 4000 to view the UI, it will not update when you save changes to JS files. The react app is live reloaded on port 3000.**  
+
+ # Resources used  
+### Making react and phoenix talk via websockets  
+I'd never got a react/phoenix app talking to each other. These articles were useful:  
 https://www.viget.com/articles/phoenix-and-react-a-killer-combo  
 http://www.east5th.co/blog/2017/04/03/using-create-react-app-with-phoenix/

--- a/lib/a_thousand_words/artifacts/picture.ex
+++ b/lib/a_thousand_words/artifacts/picture.ex
@@ -15,7 +15,7 @@ defmodule AThousandWords.Artifacts.Picture do
   @doc false
   def changeset(%Picture{} = picture, attrs) do
     picture
-    |> cast(attrs, [])
-    |> validate_required([])
+    |> cast(attrs, [:name, :description, :year, :location])
+    |> validate_required([:name, :description])
   end
 end

--- a/lib/a_thousand_words/web/channels/artifacts/picture/picture_channel.ex
+++ b/lib/a_thousand_words/web/channels/artifacts/picture/picture_channel.ex
@@ -1,0 +1,94 @@
+defmodule AThousandWords.Web.Artifacts.PictureChannel do
+  use AThousandWords.Web, :channel
+  alias AThousandWords.Artifacts
+  alias AThousandWords.Artifacts.Picture
+  @moduledoc """
+  A channel allowing a client to perform CRUD actions on Pictures.
+  """
+
+  def join("artifacts:picture", payload, socket) do
+    if authorized?(payload) do
+      {:ok, %{message: "Joined the pictures channel"}, socket}
+    else
+      {:error, %{reason: "unauthorized"}}
+    end
+  end
+
+  # Test message TODO delete this
+  def handle_in("ping", payload, socket) do
+    {:reply, {:ok, payload}, socket}
+  end
+
+  @doc """
+  Replies with a payload containing a list of all the picture structs.
+  """
+  def handle_in("list_pictures", payload, socket) do
+    pictures = Artifacts.list_pictures()
+    {:reply, {:ok, %{pictures: pictures}}, socket}
+  end
+
+  @doc """
+  When passed a payload containing a valid id, replies with the picture from the db.
+
+  If the payload does not contain a valid id, replies with an error.
+  """
+  def handle_in("get_picture", %{"id" => picture_id}, socket) do
+    with %Picture{} = picture <- Artifacts.get_picture!(picture_id) do
+      {:reply, {:ok, %{picture: picture}}, socket}
+    else
+      _error ->
+        {:reply, :error, socket}
+    end
+  end
+
+  @doc """
+  When passed a payload of picture params, this function will create a new picture in the db 
+  and reply with that picture as a payload to the client.
+
+  If the params are not valid, it will reply with an error and a reason.
+  """
+  def handle_in("create_picture", %{"params" => picture_params}, socket) do
+    with {:ok, %Picture{} = picture} <- Artifacts.create_picture(picture_params) do
+      {:reply, {:ok, %{picture: picture}}, socket}
+    else
+      {:error, reason} -> 
+        {:reply, {:error, %{reason: reason}}, socket}
+    end
+  end
+
+  @doc """
+  When passed the id of a valid picture object already in the db and some params to update,
+  this will update the picture object in the db and return the new picture as the payload to the client.
+
+  If it fails to update the picture, it will reply with an error.
+  """
+  def handle_in("update_picture", %{"params" => picture_params, "id" => picture_id}, socket) do
+    with %Picture{} = picture <- Artifacts.get_picture!(picture_id) do
+      with {:ok, %Picture{} = updated_picture} <- Artifacts.update_picture(picture, picture_params) do
+        {:reply, {:ok, %{"picture" => updated_picture}}, socket}
+      end
+    else
+      _error ->
+        {:reply, :error, socket}
+    end
+  end
+
+  @doc """
+  Deletes the picture with the given id from the db if the payload contains a valid picture's id.
+  """
+  def handle_in("delete_picture", %{"id" => picture_id}, socket) do
+    with %Picture{} = picture <-Artifacts.get_picture!(picture_id) do
+      with {:ok, %Picture{}} <- Artifacts.delete_picture(picture) do
+        {:reply, :ok, socket}
+      end
+    else
+      _error -> 
+        {:reply, :error, socket}
+    end
+  end
+
+  # Add authorization logic here as required.
+  defp authorized?(_payload) do
+    true
+  end
+end

--- a/lib/a_thousand_words/web/channels/user_socket.ex
+++ b/lib/a_thousand_words/web/channels/user_socket.ex
@@ -4,6 +4,7 @@ defmodule AThousandWords.Web.UserSocket do
   ## Channels
   # channel "room:*", AThousandWords.Web.RoomChannel
   channel "hello:*", AThousandWords.Web.HelloChannel
+  channel "artifacts:pictures", AThousandWords.Web.Artifacts.PictureChannel
 
   ## Transports
   transport :websocket, Phoenix.Transports.WebSocket

--- a/lib/a_thousand_words/web/channels/user_socket.ex
+++ b/lib/a_thousand_words/web/channels/user_socket.ex
@@ -4,7 +4,7 @@ defmodule AThousandWords.Web.UserSocket do
   ## Channels
   # channel "room:*", AThousandWords.Web.RoomChannel
   channel "hello:*", AThousandWords.Web.HelloChannel
-  channel "artifacts:pictures", AThousandWords.Web.Artifacts.PictureChannel
+  channel "artifacts:picture", AThousandWords.Web.Artifacts.PictureChannel
 
   ## Transports
   transport :websocket, Phoenix.Transports.WebSocket

--- a/priv/repo/seeds.exs
+++ b/priv/repo/seeds.exs
@@ -9,3 +9,12 @@
 #
 # We recommend using the bang functions (`insert!`, `update!`
 # and so on) as they will fail if something goes wrong.
+
+AThousandWords.Repo.delete_all AThousandWords.Artifacts.Picture 
+
+AThousandWords.Repo.insert!(%AThousandWords.Artifacts.Picture{
+  name: "Terringes Avenue", 
+  description: "the second house I lived in as a child",
+  year: 1995, 
+  location: %Geo.Point{coordinates: {-0.39661288261413574, 50.82542338342201}, srid: nil}
+})

--- a/test/a_thousand_words/artifacts/artifacts_test.exs
+++ b/test/a_thousand_words/artifacts/artifacts_test.exs
@@ -6,9 +6,15 @@ defmodule AThousandWords.ArtifactsTest do
   describe "pictures" do
     alias AThousandWords.Artifacts.Picture
 
-    @valid_attrs %{}
-    @update_attrs %{}
-    @invalid_attrs %{}
+    @geoJSON_point %{"coordinates" => [-0.15157699584960938, 51.434106241971826], "type" => "Point"}
+    @geoJSON_polygon %{ "coordinates" => [[[-0.1526927947998047, 51.42979863875662],
+                        [-0.13385295867919922, 51.42979863875662],
+                        [-0.13385295867919922, 51.4365407945686],
+                        [-0.1526927947998047, 51.4365407945686],
+                        [-0.1526927947998047, 51.42979863875662]]], "type" => "Polygon"}
+    @valid_attrs %{year: 1960, name: "My Childhood Home", description: "Where I grew up", location: @geoJSON_point}
+    @update_attrs %{year: 1961, name: "My Childhood Home", description: "Where I grew up", location: @geoJSON_polygon}
+    @invalid_attrs %{ year: 1999, description: 0001010101010101001}
 
     def picture_fixture(attrs \\ %{}) do
       {:ok, picture} =

--- a/test/a_thousand_words/web/channels/artifacts/picture/picture_channel_test.exs
+++ b/test/a_thousand_words/web/channels/artifacts/picture/picture_channel_test.exs
@@ -1,0 +1,59 @@
+defmodule AThousandWords.Web.Artifacts.PictureChannelTest do
+  use AThousandWords.Web.ChannelCase
+  alias AThousandWords.Web.Artifacts.PictureChannel
+  alias AThousandWords.Artifacts
+  alias AThousandWords.Repo
+
+  @picture_params %{ "description" => "My grandad's house",
+                    "location" => %{"coordinates" => [-0.33210039138793945, 50.882148345079656],
+                                    "type" => "Point"}, 
+                    "name" => "Penlands Vale", "year" => 1999}
+
+  setup do
+    {:ok, _, socket} =
+      socket("user_id", %{some: :assign})
+      |> subscribe_and_join(PictureChannel, "artifacts:picture")
+    {:ok, socket: socket, params: @picture_params}
+  end
+
+  test "ping replies with status ok", %{socket: socket} do
+    ref = push socket, "ping", %{"hello" => "there"}
+    assert_reply ref, :ok, %{"hello" => "there"}
+  end
+
+  test "list_pictures sends a reply containing all the pictures", %{socket: socket} do
+    expected_payload = %{pictures: Artifacts.list_pictures()}
+    ref = push socket, "list_pictures", %{}
+    assert_reply ref, :ok, ^expected_payload
+  end
+
+  test "create_picture creates a picture in the db using the payload", %{socket: socket, params: params} do
+    ref = push socket, "create_picture", %{"params" => params}
+    assert_reply ref, :ok, returned_payload
+    assert is_map(returned_payload.picture)
+    assert Repo.all(Artifacts.Picture) != []
+  end
+
+  test "update_picture updates a picture in the db using the payload", %{socket: socket, params: params} do
+    {:ok, %Artifacts.Picture{id: id}} = Artifacts.create_picture(params)
+    update_params = %{"year" => 2000}
+    ref = push socket, "update_picture", %{"id" => id, "params" => update_params}
+    assert_reply ref, :ok
+    assert Repo.get_by(Artifacts.Picture, id: id, year: 2000)
+  end
+
+  test "get_picture returns the picture with the given id if there was one", %{socket: socket, params: params} do
+    {:ok, %Artifacts.Picture{id: id} = picture} = Artifacts.create_picture(params)
+    ref = push socket, "get_picture", %{"id" => id}
+    expected_reply = %{picture: picture}
+    assert_reply ref, :ok, ^expected_reply
+  end
+
+  test "delete_picture deletes the picture with the given id from the db", %{socket: socket, params: params} do
+    {:ok, %Artifacts.Picture{id: id} = picture} = Artifacts.create_picture(params)
+    ref = push socket, "delete_picture", %{"id" => id}
+    assert_reply ref, :ok
+    refute Repo.get(Artifacts.Picture, id)
+  end
+
+end

--- a/test/a_thousand_words/web/controllers/picture_controller_test.exs
+++ b/test/a_thousand_words/web/controllers/picture_controller_test.exs
@@ -4,9 +4,10 @@ defmodule AThousandWords.Web.PictureControllerTest do
   alias AThousandWords.Artifacts
   alias AThousandWords.Artifacts.Picture
 
-  @create_attrs %{}
-  @update_attrs %{}
-  @invalid_attrs %{}
+  @geoJSON_point %{"coordinates" => [-0.15157699584960938, 51.434106241971826], "type" => "Point"}
+  @create_attrs %{year: 1960, name: "My Childhood Home", description: "Where I grew up", location: @geoJSON_point}
+  @update_attrs %{year: 1961, location: @geoJSON_point}
+  @invalid_attrs %{year: 1999, description: 0001010101010101001}
 
   def fixture(:picture) do
     {:ok, picture} = Artifacts.create_picture(@create_attrs)


### PR DESCRIPTION
This PR allows a client communicating with the app via websockets, on the `artifacts:picture` channel, to perform CRUD actions on pictures in the database.

check out `lib/a_thousand_words/web/channels/artifacts/picture/picture_channel.ex` for where this is happening. 

I'm going to hook up a js client in the react app for this next, in a different pr